### PR TITLE
fix: Gracefully handle missing queue time for fastify

### DIFF
--- a/fastify/src/plugin.js
+++ b/fastify/src/plugin.js
@@ -9,7 +9,9 @@ async function rawPlugin(fastify) {
     try {
       const queueTime = requestMetrics.queueTimeFromHeaders(request.headers, Date.now())
 
-      metricsStore.push('qt', queueTime)
+      if (queueTime !== null) {
+        metricsStore.push('qt', queueTime)
+      }
 
       fastify.log.debug(`Queue Time: ${queueTime} ms`)
     } catch (err) {

--- a/fastify/test/plugin.test.js
+++ b/fastify/test/plugin.test.js
@@ -1,6 +1,5 @@
 const fastify = require('fastify')
 const { Judoscale, plugin } = require('../src/plugin')
-const { MetricsStore } = require('judoscale-node-core')
 
 describe('Judoscale Fastify Plugin', () => {
   let app
@@ -33,5 +32,17 @@ describe('Judoscale Fastify Plugin', () => {
     // Queue time should be 100-200ms depending how long the test takes to run
     expect(metrics[0].value).toBeGreaterThanOrEqual(100)
     expect(metrics[0].value).toBeLessThan(200)
+  })
+
+  test('gracefully handles missing queue time', async () => {
+    await app.inject({
+      method: 'GET',
+      url: '/',
+      headers: {},
+    })
+
+    const metrics = Judoscale.adapters[0].collector.collect()
+
+    expect(metrics).toEqual([])
   })
 })


### PR DESCRIPTION
We should not be collecting metrics when there's no x-request-start header.