### PR TITLE
Add `redis_url` config option and fix the Redis connection

### DIFF
--- a/packages/bull/README.md
+++ b/packages/bull/README.md
@@ -19,11 +19,13 @@ import { Judoscale } from 'judoscale-bull'
 // CommonJS
 const { Judoscale } = require('judoscale-bull')
 
-// Initialize Judoscale with default configuration
-const judoscale = new Judoscale()
+// Initialize Judoscale with optional configuration
+const judoscale = new Judoscale({
+  redis_url: process.env.REDISCLOUD_URL, // defaults to process.env.REDIS_URL
+})
 ```
 
-3. If you want to scale your workers all the way down, you also need to install judoscale-bull in your web process:
+3. If you want to scale your workers down to zero instances, you also need to install judoscale-bull in your web process so Judoscale knows when to scale them back up:
 
 ```javascript
 // ESM
@@ -34,8 +36,10 @@ import 'judoscale-bull'
 const { Judoscale, middleware: judoscaleMiddleware } = require('judoscale-express')
 require('judoscale-bull')
 
-// Judoscale will automatically be initialized for both Bull and Express/Fastify
-const judoscale = new Judoscale()
+// Judoscale will be initialized for both Bull and Express/Fastify
+const judoscale = new Judoscale({
+  redis_url: process.env.REDISCLOUD_URL, // defaults to process.env.REDIS_URL
+})
 ```
 
 ## Troubleshooting

--- a/packages/bull/test/bull-metrics-collector.test.js
+++ b/packages/bull/test/bull-metrics-collector.test.js
@@ -1,4 +1,3 @@
-const Redis = require('ioredis')
 const Queue = require('bull')
 const BullMetricsCollector = require('../src/bull-metrics-collector')
 
@@ -9,14 +8,12 @@ describe('BullMetricsCollector', () => {
     collector = new BullMetricsCollector()
 
     // Clear all Bull information in Redis
-    const redis = new Redis({ url: this.redisUrl })
-    const keys = await redis.keys('bull:*')
-    if (keys.length) await redis.del(keys)
-    await redis.quit()
+    const keys = await collector.redis.keys('bull:*')
+    if (keys.length) await collector.redis.del(keys)
   })
 
   afterEach(async () => {
-    if (collector) await collector.closeQueues()
+    if (collector) await collector.tearDown()
     if (queue) await queue.close()
   })
 

--- a/packages/bullmq/README.md
+++ b/packages/bullmq/README.md
@@ -19,11 +19,13 @@ import { Judoscale } from 'judoscale-bullmq'
 // CommonJS
 const { Judoscale } = require('judoscale-bullmq')
 
-// Initialize Judoscale with default configuration
-const judoscale = new Judoscale()
+// Initialize Judoscale with optional configuration
+const judoscale = new Judoscale({
+  redis_url: process.env.REDISCLOUD_URL, // defaults to process.env.REDIS_URL
+})
 ```
 
-3. If you want to scale your workers all the way down, you also need to install judoscale-bullmq in your web process:
+3. If you want to scale your workers down to zero instances, you also need to install judoscale-bullmq in your web process so Judoscale knows when to scale them back up:
 
 ```javascript
 // ESM
@@ -34,8 +36,10 @@ import 'judoscale-bullmq'
 const { Judoscale, middleware: judoscaleMiddleware } = require('judoscale-express')
 require('judoscale-bullmq')
 
-// Judoscale will automatically be initialized for both BullMQ and Express/Fastify
-const judoscale = new Judoscale()
+// Judoscale will be initialized for both BullMQ and Express/Fastify
+const judoscale = new Judoscale({
+  redis_url: process.env.REDISCLOUD_URL, // defaults to process.env.REDIS_URL
+})
 ```
 
 ## Troubleshooting

--- a/packages/bullmq/src/bull-mq-metrics-collector.js
+++ b/packages/bullmq/src/bull-mq-metrics-collector.js
@@ -5,15 +5,12 @@ const { Metric, WorkerMetricsCollector } = require('judoscale-node-core')
 class BullMQMetricsCollector extends WorkerMetricsCollector {
   constructor() {
     super('BullMQ')
-
-    const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379'
-
-    this.redis = new Redis({ connection: { url: redisUrl } })
     this.queueNames = new Set()
   }
 
   async collect() {
     // TODO: New queues created after first collect() call will not be reported
+    console.log('COLLECT')
     if (this.queueNames.size == 0) await this.fetchQueueNames()
 
     let metrics = []
@@ -43,6 +40,15 @@ class BullMQMetricsCollector extends WorkerMetricsCollector {
       const queueName = redisKey.split(':')[1]
       this.queueNames.add(queueName)
     }
+  }
+
+  get redis() {
+    if (!this._redis) {
+      const redisUrl = this.config.redis_url || process.env.REDIS_URL || 'redis://127.0.0.1:6379'
+      this._redis = new Redis(redisUrl)
+    }
+
+    return this._redis
   }
 }
 

--- a/packages/node-core/src/judoscale.js
+++ b/packages/node-core/src/judoscale.js
@@ -7,9 +7,12 @@ class Judoscale {
   constructor(options) {
     this.config = new Config(options)
 
-    const reporter = new Reporter()
+    // Expose config to the collectors
+    for (const adapter of Judoscale.adapters) {
+      adapter.collector.config = this.config
+    }
 
-    reporter.start(this.config, Judoscale.adapters)
+    new Reporter().start(this.config, Judoscale.adapters)
   }
 
   static registerAdapter(identifier, collector, meta = {}) {

--- a/packages/node-core/src/web-metrics-collector.js
+++ b/packages/node-core/src/web-metrics-collector.js
@@ -2,6 +2,7 @@ class WebMetricsCollector {
   constructor(store, collectorName = 'Web') {
     this.collectorName = collectorName
     this.store = store
+    this.config = {}
   }
 
   collect() {

--- a/packages/node-core/src/worker-metrics-collector.js
+++ b/packages/node-core/src/worker-metrics-collector.js
@@ -1,6 +1,7 @@
 class WorkerMetricsCollector {
   constructor(collectorName) {
     this.collectorName = collectorName
+    this.config = {}
   }
 
   collect() {

--- a/packages/node-core/test/judoscale.test.js
+++ b/packages/node-core/test/judoscale.test.js
@@ -1,0 +1,31 @@
+/* global test, expect, describe, jest */
+
+const Judoscale = require('../src/judoscale')
+
+describe('Judoscale', () => {
+  test('registering an adapter adds it to static adapters', () => {
+    const collector = {}
+    Judoscale.registerAdapter('judoscale-test-adapter', collector, { foo: 'bar' })
+
+    expect(Judoscale.adapters.length).toEqual(1)
+    expect(Judoscale.adapters[0].identifier).toEqual('judoscale-test-adapter')
+    expect(Judoscale.adapters[0].collector).toEqual(collector)
+    expect(Judoscale.adapters[0].meta.foo).toEqual('bar')
+  })
+
+  test('passes options to config property', () => {
+    const judoscale = new Judoscale({ foo: 'bar' })
+
+    expect(judoscale.config.log_level).toEqual('info')
+    expect(judoscale.config.foo).toEqual('bar')
+  })
+
+  test('exposes config to collectors', () => {
+    const collector = {}
+    Judoscale.registerAdapter('judoscale-test-adapter', collector, { foo: 'bar' })
+
+    const judoscale = new Judoscale({ foo: 'bar' })
+
+    expect(collector.config.foo).toEqual('bar')
+  })
+})


### PR DESCRIPTION
The URL passed into the constructor was not being passed correctly, so it was falling back to localhost.