### PR TITLE
fix: Bullmq package memory leak

### DIFF
--- a/packages/bullmq/src/bull-mq-metrics-collector.js
+++ b/packages/bullmq/src/bull-mq-metrics-collector.js
@@ -17,6 +17,7 @@ class BullMQMetricsCollector extends WorkerMetricsCollector {
     for (const queueName of this.queueNames) {
       const queue = new Queue(queueName, { connection: this.redis })
       const jobCounts = await queue.getJobCounts('waiting', 'active', 'prioritized')
+      await queue.close()
 
       metrics.push(new Metric('qd', new Date(), jobCounts.waiting + jobCounts.prioritized, queueName))
       metrics.push(new Metric('busy', new Date(), jobCounts.active, queueName))


### PR DESCRIPTION
Hello Adam!

While investigating a memory leak issue in our Heroku application today, @WebTarantul and I discovered that the problem was in the `judoscale-bullmq` package. This PR fixes that leak. In our project, we're currently using patch-package, but we hope to receive an update soon that will address this issue.

Thank you for the wonderful library and service @adamlogic.