### PR TITLE
Configure runtime container for Railway

### DIFF
--- a/packages/node-core/src/config.js
+++ b/packages/node-core/src/config.js
@@ -22,6 +22,8 @@ function getDefaultOptions() {
   } else if (process.env.ECS_CONTAINER_METADATA_URI) {
     const parts = process.env.ECS_CONTAINER_METADATA_URI.split('/')
     containerID = parts[parts.length - 1]
+  } else if (process.env.RAILWAY_REPLICA_ID) {
+    containerID = process.env.RAILWAY_REPLICA_ID
   }
 
   return {

--- a/packages/node-core/src/config.js
+++ b/packages/node-core/src/config.js
@@ -12,14 +12,14 @@ function getDefaultOptions() {
   const defaultLogLevel = process.env.JUDOSCALE_LOG_LEVEL || 'info'
 
   let apiBaseUrl = process.env.JUDOSCALE_URL
-  let containerID = process.env.DYNO
+  let containerID
 
-  if (process.env.RENDER_INSTANCE_ID) {
-    containerID = process.env.RENDER_INSTANCE_ID.replace(process.env.RENDER_SERVICE_ID, '').replace('-', '')
+  if (process.env.DYNO) {
+    containerID = process.env.DYNO
+  } else if (process.env.RENDER_INSTANCE_ID) {
     apiBaseUrl ||= `https://adapter.judoscale.com/api/${process.env.RENDER_SERVICE_ID}`
-  }
-
-  if (process.env.ECS_CONTAINER_METADATA_URI) {
+    containerID = process.env.RENDER_INSTANCE_ID.replace(process.env.RENDER_SERVICE_ID, '').replace('-', '')
+  } else if (process.env.ECS_CONTAINER_METADATA_URI) {
     const parts = process.env.ECS_CONTAINER_METADATA_URI.split('/')
     containerID = parts[parts.length - 1]
   }

--- a/packages/node-core/src/config.js
+++ b/packages/node-core/src/config.js
@@ -18,7 +18,7 @@ function getDefaultOptions() {
     containerID = process.env.DYNO
   } else if (process.env.RENDER_INSTANCE_ID) {
     apiBaseUrl ||= `https://adapter.judoscale.com/api/${process.env.RENDER_SERVICE_ID}`
-    containerID = process.env.RENDER_INSTANCE_ID.replace(process.env.RENDER_SERVICE_ID, '').replace('-', '')
+    containerID = process.env.RENDER_INSTANCE_ID.replace(`${process.env.RENDER_SERVICE_ID}-`, '')
   } else if (process.env.ECS_CONTAINER_METADATA_URI) {
     const parts = process.env.ECS_CONTAINER_METADATA_URI.split('/')
     containerID = parts[parts.length - 1]

--- a/packages/node-core/test/config.test.js
+++ b/packages/node-core/test/config.test.js
@@ -4,11 +4,12 @@ const Config = require('../src/config')
 
 describe('Config', () => {
   beforeEach(() => {
+    delete process.env.JUDOSCALE_URL
+    delete process.env.DYNO
     delete process.env.RENDER_INSTANCE_ID
     delete process.env.RENDER_SERVICE_ID
-    delete process.env.DYNO
-    delete process.env.JUDOSCALE_URL
     delete process.env.ECS_CONTAINER_METADATA_URI
+    delete process.env.RAILWAY_REPLICA_ID
   })
 
   test('has logger property', () => {
@@ -49,6 +50,11 @@ describe('Config', () => {
   test('has container property for Heroku', () => {
     process.env.DYNO = 'web.123'
     expect(new Config()).toHaveProperty('container', 'web.123')
+  })
+
+  test('has container property for Railway', () => {
+    process.env.RAILWAY_REPLICA_ID = 'random-replica-uuid'
+    expect(new Config()).toHaveProperty('container', 'random-replica-uuid')
   })
 
   test('has version property', () => {

--- a/packages/node-core/test/config.test.js
+++ b/packages/node-core/test/config.test.js
@@ -5,6 +5,7 @@ const Config = require('../src/config')
 describe('Config', () => {
   beforeEach(() => {
     delete process.env.JUDOSCALE_URL
+    delete process.env.JUDOSCALE_LOG_LEVEL
     delete process.env.DYNO
     delete process.env.RENDER_INSTANCE_ID
     delete process.env.RENDER_SERVICE_ID
@@ -14,6 +15,13 @@ describe('Config', () => {
 
   test('has logger property', () => {
     expect(new Config()).toHaveProperty('logger')
+  })
+
+  test('has log_level property that can be overridden via JUDOSCALE_LOG_LEVEL', () => {
+    expect(new Config()).toHaveProperty('log_level', 'info')
+
+    process.env.JUDOSCALE_LOG_LEVEL = 'warn'
+    expect(new Config()).toHaveProperty('log_level', 'warn')
   })
 
   test('has now property', () => {


### PR DESCRIPTION
We're early-testing Railway as a platform integration, this adds detection for the Railway environment to report the runtime container as the Railway Replica ID.

It also refactors a bit the runtime container logic to match the other libs.

Related:

- https://github.com/judoscale/judoscale-ruby/pull/230
- https://github.com/judoscale/judoscale-python/pull/98