### PR TITLE
Configure runtime container for Fly.io

### DIFF
--- a/packages/node-core/src/config.js
+++ b/packages/node-core/src/config.js
@@ -22,6 +22,8 @@ function getDefaultOptions() {
   } else if (process.env.ECS_CONTAINER_METADATA_URI) {
     const parts = process.env.ECS_CONTAINER_METADATA_URI.split('/')
     containerID = parts[parts.length - 1]
+  } else if (process.env.FLY_MACHINE_ID) {
+    containerID = process.env.FLY_MACHINE_ID
   } else if (process.env.RAILWAY_REPLICA_ID) {
     containerID = process.env.RAILWAY_REPLICA_ID
   }

--- a/packages/node-core/test/config.test.js
+++ b/packages/node-core/test/config.test.js
@@ -10,6 +10,7 @@ describe('Config', () => {
     delete process.env.RENDER_INSTANCE_ID
     delete process.env.RENDER_SERVICE_ID
     delete process.env.ECS_CONTAINER_METADATA_URI
+    delete process.env.FLY_MACHINE_ID
     delete process.env.RAILWAY_REPLICA_ID
   })
 
@@ -58,6 +59,11 @@ describe('Config', () => {
   test('has container property for Heroku', () => {
     process.env.DYNO = 'web.123'
     expect(new Config()).toHaveProperty('container', 'web.123')
+  })
+
+  test('has container property for Fly', () => {
+    process.env.FLY_MACHINE_ID = 'random-machine-id'
+    expect(new Config()).toHaveProperty('container', 'random-machine-id')
   })
 
   test('has container property for Railway', () => {


### PR DESCRIPTION
Adds detection for the Fly environment to report the runtime container as the Fly Machine ID.

(The Fly.io integration is currently in early-testing)

<details><summary>Sample ENV vars</summary>
<p>

![Screenshot 2025-02-17 at 11 25 42](https://github.com/user-attachments/assets/adb13219-49f8-410e-a02d-af6fb87df638)

</p>
</details> 
