### PR TITLE
QOL improvements for consistency with the other packages

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+npm run test

--- a/sample_apps/express_web/README.md
+++ b/sample_apps/express_web/README.md
@@ -18,6 +18,6 @@ bin/dev
 
 This will run both the app and a proxy server that adds the X-Request-Start header for simulating request queue time.
 
-Visit the app through the proxy server: http://localhost:5004
+Visit the app through the proxy server: http://localhost:5006
 
 Reports are sent to Request Catcher—an API testing tool—instead of Judoscale. To view the reports that are sent, go to https://judoscale-node.requestcatcher.com.

--- a/sample_apps/express_web/bin/dev
+++ b/sample_apps/express_web/bin/dev
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-PORT=5004 heroku local
+PORT=5006 heroku local

--- a/sample_apps/express_web/src/web.js
+++ b/sample_apps/express_web/src/web.js
@@ -30,7 +30,17 @@ app.listen(port, () => {
   console.log(`Example app listening on port ${port}`)
 })
 
+const sleep = secs => new Promise(resolve => setTimeout(resolve, secs * 1000))
+const randomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min
+
 async function handleIndex(req, res) {
+  // Accept a `?sleep=N` query param to sleep for the specified N of seconds,
+  // or `?sleep=true` to sleep randomly for 0-2 seconds.
+  if (req.query.sleep) {
+    const sleepFor = parseInt(req.query.sleep)
+    await sleep(isNaN(sleepFor) ? randomInt(0, 2) : sleepFor)
+  }
+
   const keys = await redis.keys('bull:*:id')
   const queueNames = keys.map((key) => key.split(':')[1])
 

--- a/sample_apps/fastify_web/README.md
+++ b/sample_apps/fastify_web/README.md
@@ -18,6 +18,6 @@ bin/dev
 
 This will run both the app and a proxy server that adds the X-Request-Start header for simulating request queue time.
 
-Visit the app through the proxy server: http://localhost:5004
+Visit the app through the proxy server: http://localhost:5006
 
 Reports are sent to Request Catcher—an API testing tool—instead of Judoscale. To view the reports that are sent, go to https://judoscale-node.requestcatcher.com.

--- a/sample_apps/fastify_web/bin/dev
+++ b/sample_apps/fastify_web/bin/dev
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-PORT=5004 heroku local
+PORT=5006 heroku local

--- a/sample_apps/fastify_web/src/web.js
+++ b/sample_apps/fastify_web/src/web.js
@@ -35,7 +35,17 @@ fastify.listen({ port: process.env.PORT || 3000 }, function (err, address) {
   }
 })
 
+const sleep = secs => new Promise(resolve => setTimeout(resolve, secs * 1000))
+const randomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min
+
 async function handleIndex(req, reply) {
+  // Accept a `?sleep=N` query param to sleep for the specified N of seconds,
+  // or `?sleep=<not-a-number>` to sleep randomly for 0-2 seconds.
+  if (req.query.sleep) {
+    const sleepFor = parseInt(req.query.sleep)
+    await sleep(isNaN(sleepFor) ? randomInt(0, 2) : sleepFor)
+  }
+
   const keys = await redis.keys('bull:*:id')
   const queueNames = keys.map((key) => key.split(':')[1])
 


### PR DESCRIPTION
Improvements to make Node package development experience similar to Ruby/Python:

* Switch port to `5006`
* Add ability to sleep for a duration or randomly to the sample apps (pass `?sleep=N` or `?sleep=true`)
* Add `bin/test` script to run tests