### PR TITLE
feat: Collect & report app time with Fastify/Express

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1258,6 +1258,19 @@
         "win32"
       ]
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1291,6 +1304,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1778,6 +1801,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "2.6.4",
@@ -2355,6 +2385,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2399,6 +2439,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -2619,6 +2666,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff-sequences": {
@@ -3763,6 +3821,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.3.0.tgz",
@@ -3974,6 +4039,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -7614,6 +7697,89 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8315,7 +8481,8 @@
       },
       "devDependencies": {
         "jest": "^27.5.1",
-        "standard": "^17.1.0"
+        "standard": "^17.1.0",
+        "supertest": "^7.1.4"
       },
       "peerDependencies": {
         "express": "^4.0.0"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -19,7 +19,8 @@
   },
   "devDependencies": {
     "jest": "^27.5.1",
-    "standard": "^17.1.0"
+    "standard": "^17.1.0",
+    "supertest": "^7.1.4"
   },
   "peerDependencies": {
     "express": "^4.0.0"

--- a/packages/express/src/index.js
+++ b/packages/express/src/index.js
@@ -4,16 +4,26 @@ const packageInfo = require('../package.json')
 const store = new MetricsStore()
 
 function middleware(judoscale) {
-  return ({ headers }, _res, next) => {
+  return (req, res, next) => {
     const now = judoscale.config.now || new Date()
-    const queueTime = requestMetrics.queueTimeFromHeaders(headers, now)
+    const queueTime = requestMetrics.queueTimeFromHeaders(req.headers, now)
+    const requestId = requestMetrics.requestId(req.headers)
 
     if (queueTime !== null) {
-      judoscale.config.logger.debug(
-        `[Judoscale] queue_time=${queueTime}ms request_id=${requestMetrics.requestId(headers)}`
-      )
+      judoscale.config.logger.debug(`[Judoscale] queue_time=${queueTime}ms request_id=${requestId}`)
       store.push('qt', queueTime)
     }
+
+    const startTime = process.hrtime.bigint();
+
+    res.on('finish', () => {
+      const endTime = process.hrtime.bigint();
+      const appTimeNs = endTime - startTime
+      const appTimeMs = Math.floor(Number(appTimeNs) / 1_000_000)
+
+      store.push('at', appTimeMs)
+      judoscale.config.logger.debug(`[Judoscale] app_time=${appTimeMs}ms request_id=${requestId}`)
+    })
 
     next()
   }

--- a/packages/express/src/index.js
+++ b/packages/express/src/index.js
@@ -5,8 +5,7 @@ const metricsStore = new MetricsStore()
 
 function middleware(judoscale) {
   return (req, res, next) => {
-    const now = judoscale.config.now || new Date()
-    const queueTime = requestMetrics.queueTimeFromHeaders(req.headers, now)
+    const queueTime = requestMetrics.queueTimeFromHeaders(req.headers, new Date())
     const requestId = requestMetrics.requestId(req.headers)
 
     if (queueTime !== null) {

--- a/packages/express/src/index.js
+++ b/packages/express/src/index.js
@@ -14,15 +14,13 @@ function middleware(judoscale) {
       store.push('qt', queueTime)
     }
 
-    const startTime = process.hrtime.bigint();
+    const startTime = requestMetrics.monotonicTime()
 
     res.on('finish', () => {
-      const endTime = process.hrtime.bigint();
-      const appTimeNs = endTime - startTime
-      const appTimeMs = Math.floor(Number(appTimeNs) / 1_000_000)
+      const appTime = requestMetrics.elapsedTime(startTime)
+      store.push('at', appTime)
 
-      store.push('at', appTimeMs)
-      judoscale.config.logger.debug(`[Judoscale] app_time=${appTimeMs}ms request_id=${requestId}`)
+      judoscale.config.logger.debug(`[Judoscale] app_time=${appTime}ms request_id=${requestId}`)
     })
 
     next()

--- a/packages/express/src/test/index.test.js
+++ b/packages/express/src/test/index.test.js
@@ -25,10 +25,13 @@ describe('middleware', () => {
     expect(response.text).toBe('Middleware test')
 
     const metrics = Judoscale.adapters[0].collector.collect()
-    expect(metrics.length).toEqual(1)
+    expect(metrics.length).toEqual(2)
     // Queue time should be 100-200ms depending how long the test takes to run
+    expect(metrics[0].identifier).toEqual('qt')
     expect(metrics[0].value).toBeGreaterThanOrEqual(100)
     expect(metrics[0].value).toBeLessThan(200)
+    expect(metrics[1].identifier).toEqual('at')
+    expect(metrics[1].value).toBeGreaterThanOrEqual(0)
   })
 
   test('gracefully handles missing queue time', async () => {
@@ -36,6 +39,8 @@ describe('middleware', () => {
     expect(response.statusCode).toBe(200)
 
     const metrics = Judoscale.adapters[0].collector.collect()
-    expect(metrics).toEqual([])
+    // Only app time is tracked, queue time isn't.
+    expect(metrics.length).toEqual(1)
+    expect(metrics[0].identifier).toEqual('at')
   })
 })

--- a/packages/fastify/src/plugin.js
+++ b/packages/fastify/src/plugin.js
@@ -11,11 +11,10 @@ async function rawPlugin(fastify) {
 
       if (queueTime !== null) {
         metricsStore.push('qt', queueTime)
+        fastify.log.debug(`[Judoscale] queue_time=${queueTime}ms`)
       }
-
-      fastify.log.debug(`Queue Time: ${queueTime} ms`)
     } catch (err) {
-      fastify.log.error(err, 'Error processing request queue time')
+      fastify.log.error(err, '[Judoscale] Error processing request queue time')
     }
   })
 
@@ -25,9 +24,8 @@ async function rawPlugin(fastify) {
 
   fastify.addHook('onResponse', async (request, _reply) => {
     const appTime = requestMetrics.elapsedTime(request.judoscaleAppStartTime)
-
     metricsStore.push('at', appTime)
-    fastify.log.debug(`App Time: ${appTime} ms`)
+    fastify.log.debug(`[Judoscale] app_time=${appTime}ms`)
   })
 }
 

--- a/packages/fastify/src/plugin.js
+++ b/packages/fastify/src/plugin.js
@@ -20,16 +20,14 @@ async function rawPlugin(fastify) {
   })
 
   fastify.addHook('onRequest', async (request, _reply) => {
-    request.judoscaleAppStartTime = process.hrtime.bigint()
+    request.judoscaleAppStartTime = requestMetrics.monotonicTime()
   })
 
   fastify.addHook('onResponse', async (request, _reply) => {
-    const endTime = process.hrtime.bigint()
-    const appTimeNs = endTime - request.judoscaleAppStartTime
-    const appTimeMs = Math.floor(Number(appTimeNs) / 1_000_000)
+    const appTime = requestMetrics.elapsedTime(request.judoscaleAppStartTime)
 
-    metricsStore.push('at', appTimeMs)
-    fastify.log.debug(`App Time: ${appTimeMs} ms`)
+    metricsStore.push('at', appTime)
+    fastify.log.debug(`App Time: ${appTime} ms`)
   })
 }
 

--- a/packages/fastify/src/plugin.js
+++ b/packages/fastify/src/plugin.js
@@ -6,15 +6,11 @@ const metricsStore = new MetricsStore()
 
 async function rawPlugin(fastify) {
   fastify.addHook('onRequest', async (request, _reply) => {
-    try {
-      const queueTime = requestMetrics.queueTimeFromHeaders(request.headers, Date.now())
+    const queueTime = requestMetrics.queueTimeFromHeaders(request.headers, Date.now())
 
-      if (queueTime !== null) {
-        metricsStore.push('qt', queueTime)
-        fastify.log.debug(`[Judoscale] queue_time=${queueTime}ms`)
-      }
-    } catch (err) {
-      fastify.log.error(err, '[Judoscale] Error processing request queue time')
+    if (queueTime !== null) {
+      metricsStore.push('qt', queueTime)
+      fastify.log.debug(`[Judoscale] queue_time=${queueTime}ms`)
     }
   })
 

--- a/packages/fastify/src/plugin.js
+++ b/packages/fastify/src/plugin.js
@@ -18,6 +18,19 @@ async function rawPlugin(fastify) {
       fastify.log.error(err, 'Error processing request queue time')
     }
   })
+
+  fastify.addHook('onRequest', async (request, _reply) => {
+    request.judoscaleAppStartTime = process.hrtime.bigint()
+  })
+
+  fastify.addHook('onResponse', async (request, _reply) => {
+    const endTime = process.hrtime.bigint()
+    const appTimeNs = endTime - request.judoscaleAppStartTime
+    const appTimeMs = Math.floor(Number(appTimeNs) / 1_000_000)
+
+    metricsStore.push('at', appTimeMs)
+    fastify.log.debug(`App Time: ${appTimeMs} ms`)
+  })
 }
 
 const plugin = fp(rawPlugin, {

--- a/packages/fastify/src/plugin.js
+++ b/packages/fastify/src/plugin.js
@@ -6,7 +6,7 @@ const metricsStore = new MetricsStore()
 
 async function rawPlugin(fastify) {
   fastify.addHook('onRequest', async (request, _reply) => {
-    const queueTime = requestMetrics.queueTimeFromHeaders(request.headers, Date.now())
+    const queueTime = requestMetrics.queueTimeFromHeaders(request.headers, new Date())
 
     if (queueTime !== null) {
       metricsStore.push('qt', queueTime)

--- a/packages/fastify/test/plugin.test.js
+++ b/packages/fastify/test/plugin.test.js
@@ -27,11 +27,14 @@ describe('Judoscale Fastify Plugin', () => {
 
     const metrics = Judoscale.adapters[0].collector.collect()
 
-    expect(metrics.length).toEqual(1)
+    expect(metrics.length).toEqual(2)
 
     // Queue time should be 100-200ms depending how long the test takes to run
+    expect(metrics[0].identifier).toEqual('qt')
     expect(metrics[0].value).toBeGreaterThanOrEqual(100)
     expect(metrics[0].value).toBeLessThan(200)
+    expect(metrics[1].identifier).toEqual('at')
+    expect(metrics[1].value).toBeGreaterThanOrEqual(0)
   })
 
   test('gracefully handles missing queue time', async () => {
@@ -43,6 +46,8 @@ describe('Judoscale Fastify Plugin', () => {
 
     const metrics = Judoscale.adapters[0].collector.collect()
 
-    expect(metrics).toEqual([])
+    // Only app time is tracked, queue time isn't.
+    expect(metrics.length).toEqual(1)
+    expect(metrics[0].identifier).toEqual('at')
   })
 })

--- a/packages/fastify/test/plugin.test.js
+++ b/packages/fastify/test/plugin.test.js
@@ -1,34 +1,42 @@
+/* global test, expect, describe, beforeAll, afterAll */
+
 const fastify = require('fastify')
 const { Judoscale, plugin } = require('../src/plugin')
 
+const app = fastify()
+app.register(plugin, new Judoscale())
+app.get('/test', async (_request, _reply) => {
+  return { message: 'Middleware test' }
+})
+
+test('adapter is registered', () => {
+  expect(Judoscale.adapters.length).toEqual(1)
+  expect(Judoscale.adapters[0].identifier).toEqual('judoscale-fastify')
+})
+
 describe('Judoscale Fastify Plugin', () => {
-  let app
-
-  beforeEach(async () => {
-    app = fastify()
-    app.register(plugin)
-
+  beforeAll(async () => {
     await app.ready()
   })
 
-  afterEach(() => app.close())
+  afterAll(async () => {
+    await app.close()
+  })
 
   test('captures request queue time and returns it from the collector', async () => {
     // Simulate 100ms queue time
     const simulatedHeaderTime = Date.now() - 100
 
-    await app.inject({
+    const response = await app.inject({
       method: 'GET',
-      url: '/',
-      headers: {
-        'x-request-start': simulatedHeaderTime.toString(),
-      },
+      url: '/test',
+      headers: { 'x-request-start': simulatedHeaderTime.toString() }
     })
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.body)).toEqual({ message: 'Middleware test' })
 
     const metrics = Judoscale.adapters[0].collector.collect()
-
     expect(metrics.length).toEqual(2)
-
     // Queue time should be 100-200ms depending how long the test takes to run
     expect(metrics[0].identifier).toEqual('qt')
     expect(metrics[0].value).toBeGreaterThanOrEqual(100)
@@ -38,14 +46,14 @@ describe('Judoscale Fastify Plugin', () => {
   })
 
   test('gracefully handles missing queue time', async () => {
-    await app.inject({
+    const response = await app.inject({
       method: 'GET',
-      url: '/',
-      headers: {},
+      url: '/test',
+      headers: {}
     })
+    expect(response.statusCode).toBe(200)
 
     const metrics = Judoscale.adapters[0].collector.collect()
-
     // Only app time is tracked, queue time isn't.
     expect(metrics.length).toEqual(1)
     expect(metrics[0].identifier).toEqual('at')

--- a/packages/node-core/src/config.js
+++ b/packages/node-core/src/config.js
@@ -35,7 +35,6 @@ function getDefaultOptions() {
     log_level: defaultLogLevel,
     container: containerID,
     report_interval_seconds: 10,
-    now: null,
   }
 }
 

--- a/packages/node-core/src/request-metrics.js
+++ b/packages/node-core/src/request-metrics.js
@@ -18,11 +18,11 @@ function requestId(headers) {
 }
 
 function elapsedTime(startTime) {
-    const endTime = monotonicTime()
-    const appTimeNs = endTime - startTime
-    const appTimeMs = Math.floor(Number(appTimeNs) / 1_000_000)
+  const endTime = monotonicTime()
+  const appTimeNs = endTime - startTime
+  const appTimeMs = Math.floor(Number(appTimeNs) / 1_000_000)
 
-    return appTimeMs
+  return appTimeMs
 }
 
 function monotonicTime() {

--- a/packages/node-core/src/request-metrics.js
+++ b/packages/node-core/src/request-metrics.js
@@ -17,7 +17,21 @@ function requestId(headers) {
   return headers['x-request-id']
 }
 
+function elapsedTime(startTime) {
+    const endTime = monotonicTime()
+    const appTimeNs = endTime - startTime
+    const appTimeMs = Math.floor(Number(appTimeNs) / 1_000_000)
+
+    return appTimeMs
+}
+
+function monotonicTime() {
+  return process.hrtime.bigint()
+}
+
 module.exports = {
   queueTimeFromHeaders,
   requestId,
+  elapsedTime,
+  monotonicTime
 }

--- a/packages/node-core/src/request-metrics.js
+++ b/packages/node-core/src/request-metrics.js
@@ -1,3 +1,5 @@
+const process = require('process');
+
 function queueTimeFromHeaders(headers, now) {
   // Heroku sets the header as integer milliseconds.
   // NGINX sets the header as fractional sections preceeded by "t=".
@@ -19,14 +21,13 @@ function requestId(headers) {
 
 function elapsedTime(startTime) {
   const endTime = monotonicTime()
-  const appTimeNs = endTime - startTime
-  const appTimeMs = Math.floor(Number(appTimeNs) / 1_000_000)
-
-  return appTimeMs
+  return Math.floor(endTime - startTime)
 }
 
 function monotonicTime() {
-  return process.hrtime.bigint()
+  // `hrtime.bigint()` returns current high-resolution real time in nanoseconds,
+  // we convert to work with milliseconds.
+  return Number(process.hrtime.bigint()) / 1_000_000
 }
 
 module.exports = {

--- a/packages/node-core/test/config.test.js
+++ b/packages/node-core/test/config.test.js
@@ -25,10 +25,6 @@ describe('Config', () => {
     expect(new Config()).toHaveProperty('log_level', 'warn')
   })
 
-  test('has now property', () => {
-    expect(new Config()).toHaveProperty('now', null)
-  })
-
   test('has api_base_url property', () => {
     process.env.JUDOSCALE_URL = 'HO HO HO'
     expect(new Config()).toHaveProperty('api_base_url', 'HO HO HO')

--- a/packages/node-core/test/request-metrics.test.js
+++ b/packages/node-core/test/request-metrics.test.js
@@ -1,5 +1,12 @@
 /* global test, expect, describe */
 
+jest.mock('process', () => {
+  return {
+    ...jest.requireActual('process'),
+    hrtime: { bigint: jest.fn().mockReturnValue(1_000_000_000_000) }
+  }
+})
+
 const RequestMetrics = require('../src/request-metrics')
 
 describe('RequestMetrics', () => {
@@ -36,6 +43,17 @@ describe('RequestMetrics', () => {
   describe('requestId', () => {
     test('Request ID from headers', () => {
       expect(RequestMetrics.requestId({ 'x-request-id': 'someidvalue' })).toBe('someidvalue')
+    })
+  })
+
+  describe('elapsedTime', () => {
+    test('Calculates elapsed time in milliseconds from the given start time', () => {
+      expect(RequestMetrics.monotonicTime()).toBe(1_000_000)
+
+      expect(RequestMetrics.elapsedTime(1_000_000)).toBe(0)
+      expect(RequestMetrics.elapsedTime(999_999)).toBe(1)
+      expect(RequestMetrics.elapsedTime(999_000)).toBe(1_000)
+      expect(RequestMetrics.elapsedTime(500_000)).toBe(500_000)
     })
   })
 })


### PR DESCRIPTION
https://github.com/judoscale/judoscale-python/pull/104
https://github.com/judoscale/judoscale-ruby/pull/238

### Samples

Tested with random sleep between 0-2 on the test apps:

```
$ hey -c 10 -n 100 'http://localhost:5006?sleep=random'
```

<details><summary>Fastify</summary>
<p>

<img width="963" height="531" alt="Screenshot 2025-09-02 at 16 03 21" src="https://github.com/user-attachments/assets/d3cb2ac1-1f47-43bc-ac97-daba2db21aec" />

</p>
</details> 

<details><summary>Express</summary>
<p>

<img width="989" height="538" alt="Screenshot 2025-09-02 at 16 02 33" src="https://github.com/user-attachments/assets/3999f2ff-8533-43cb-ac73-e5a95375f97f" />

</p>
</details> 