### PR TITLE
fix: Sleep before running & reporting the first metrics collection

### DIFF
--- a/packages/node-core/src/reporter.js
+++ b/packages/node-core/src/reporter.js
@@ -22,8 +22,6 @@ class Reporter {
         `[Judoscale] Reporter starting, will report every ${config.report_interval_seconds} seconds. Adapters: [${adapterMsg}]`
       )
 
-      this.report(adapters, config)
-
       forever((next) => {
         setTimeout(() => {
           this.report(adapters, config).then(() => {


### PR DESCRIPTION
Do not send an initial report when starting the process, sleep first for the configured interval and then collect & report metrics.

This brings the implementation inline with Python (which was already doing it like this), and Ruby (which recently changed to match): https://github.com/judoscale/judoscale-ruby/pull/249