### PR TITLE
Use native fetch if available

### DIFF
--- a/packages/node-core/src/api.js
+++ b/packages/node-core/src/api.js
@@ -1,4 +1,4 @@
-const fetch = require('node-fetch')
+const fetch = globalThis.fetch || require('node-fetch')
 
 class Api {
   constructor(config) {


### PR DESCRIPTION
Fixes #78, where `require('node-fetch')` fails to return the `fetch` function as expected for apps using NextJS, resulting in "fetch is not a function" error.

This does NOT fix the `require` for NextJS apps—instead we're assuming that anyone using NextJS is also using Node v18 or higher, a constraint we'll be adding soon to the package as a whole. For anyone using NextJS and Node < v18, they'll still get the error, but right now I don't think we have any users who fit those criteria.

Refs:
- [`fetch` announced as part of Node v18](https://nodejs.org/en/blog/announcements/v18-release-announce?utm_source=chatgpt.com)
- [current NodeJS release & maintenance schedule](https://nodejs.org/en/about/previous-releases)
- [previous discussion about node-fetch vs. built-in fetch](https://github.com/judoscale/judoscale-node/pull/62#discussion_r2293989913)