### PR TITLE
feat(nextjs): add judoscale-nextjs adapter

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -1,0 +1,41 @@
+name: Next.js adapter tests
+
+on:
+  push:
+    branches: [main]
+  pull_request: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x, 24.x, 25.x]
+        next-version: [14.x, 15.x]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-next-${{ matrix.next-version }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install Next.js ${{ matrix.next-version }}
+        run: npm install next@${{ matrix.next-version }}
+        working-directory: packages/nextjs
+
+      - name: Run tests
+        run: npm test
+        working-directory: packages/nextjs

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,6 @@
   "packages/express": "2.3.1",
   "packages/fastify": "2.4.1",
   "packages/bullmq": "2.2.1",
-  "packages/bull": "2.1.1"
+  "packages/bull": "2.1.1",
+  "packages/nextjs": "2.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ These packages work together with the [Judoscale](https://judoscale.com) autosca
 
 - [Express](https://github.com/judoscale/judoscale-node/tree/main/packages/express)
 - [Fastify](https://github.com/judoscale/judoscale-node/tree/main/packages/fastify)
+- [Next.js](https://github.com/judoscale/judoscale-node/tree/main/packages/nextjs) (self-hosted Node.js / `next start`)
 - [BullMQ](https://github.com/judoscale/judoscale-node/tree/main/packages/bullmq)
 - [Bull](https://github.com/judoscale/judoscale-node/tree/main/packages/bull)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.6.tgz",
       "integrity": "sha512-qAHSfAdVyFmIvl0VHELib8xar7ONuSHrE2hLnsaWkYNTI68dmi1x8GYDhJjMI/e7XWal9QBlZkwbOnkcw7Z8gQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.6",
@@ -536,6 +535,15 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -885,10 +893,451 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@ioredis/commands": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1313,6 +1762,131 @@
         "win32"
       ]
     },
+    "node_modules/@next/env": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g=="
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -1399,6 +1973,14 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -1570,7 +2152,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2134,7 +2715,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001587",
         "electron-to-chromium": "^1.4.668",
@@ -2302,7 +2882,6 @@
       "version": "1.0.30001625",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001625.tgz",
       "integrity": "sha512-4KE9N2gcRH+HQhpeiRZXd+1niLB/XNLAhSy4z7fI8EzcbcPoAqjNInxVHTiTwWfTIV4w096XG8OtCOCQQKPv3w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2362,6 +2941,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
       "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
       "dev": true
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -2736,6 +3320,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3049,7 +3642,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3247,7 +3839,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -3309,7 +3900,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
       "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
@@ -3335,7 +3925,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.2.0.tgz",
       "integrity": "sha512-QmAqwizauvnKOlifxyDj2ObfULpHQawlg/zQdgEixur9vl0CvZGv/LCJV2rtj3210QCoeGBzVMfMXqGAOr/4fA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -3351,7 +3940,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.2.tgz",
       "integrity": "sha512-2HCmrU+/JNigDN6tg55cRDKCQWicYAPB38JGSFDQt95jDm8rrvSUo7YPkOIm5l6ts1j1zCvysNcasvfTMQzUOw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -3899,7 +4487,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fastify/ajv-compiler": "^4.0.5",
         "@fastify/error": "^4.0.0",
@@ -4591,11 +5178,11 @@
       }
     },
     "node_modules/ioredis": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.1.tgz",
-      "integrity": "sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "dependencies": {
-        "@ioredis/commands": "^1.1.1",
+        "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.4",
         "denque": "^2.1.0",
@@ -5805,6 +6392,10 @@
       "resolved": "packages/fastify",
       "link": true
     },
+    "node_modules/judoscale-nextjs": {
+      "resolved": "packages/nextjs",
+      "link": true
+    },
     "node_modules/judoscale-node-core": {
       "resolved": "packages/node-core",
       "link": true
@@ -5815,6 +6406,10 @@
     },
     "node_modules/judoscale-sample-fastify": {
       "resolved": "sample_apps/fastify_web",
+      "link": true
+    },
+    "node_modules/judoscale-sample-next": {
+      "resolved": "sample_apps/next_web",
       "link": true
     },
     "node_modules/keyv": {
@@ -6213,6 +6808,23 @@
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6226,6 +6838,57 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/next": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
+      "dependencies": {
+        "@next/env": "15.5.18",
+        "@swc/helpers": "0.5.15",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
+        "sharp": "^0.34.3"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-abort-controller": {
@@ -6631,7 +7294,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -6794,6 +7456,33 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -6999,6 +7688,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {
@@ -7329,6 +8037,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
+    },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
@@ -7346,9 +8059,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7469,6 +8182,50 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7606,6 +8363,14 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7887,6 +8652,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/superagent": {
       "version": "10.2.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
@@ -8095,9 +8882,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10176,6 +10963,25 @@
         "fastify": "^4.0.0 || ^5.0.0"
       }
     },
+    "packages/nextjs": {
+      "name": "judoscale-nextjs",
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "judoscale-node-core": "2.5.1"
+      },
+      "devDependencies": {
+        "jest": "^29.7.0",
+        "next": "^15.0.0",
+        "standard": "^17.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "next": "^14.0.0 || ^15.0.0"
+      }
+    },
     "packages/node-core": {
       "name": "judoscale-node-core",
       "version": "2.5.1",
@@ -11682,6 +12488,20 @@
         "fastify": "^5.7.4",
         "judoscale-bull": "*",
         "judoscale-fastify": "*"
+      }
+    },
+    "sample_apps/next_web": {
+      "name": "judoscale-sample-next",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "bullmq": "^5.7.9",
+        "ioredis": "^5.6.0",
+        "judoscale-bullmq": "*",
+        "judoscale-nextjs": "*",
+        "next": "^15.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     }
   }

--- a/packages/nextjs/CHANGELOG.md
+++ b/packages/nextjs/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -1,0 +1,89 @@
+# Judoscale for Next.js
+
+Official [Judoscale](https://judoscale.com) adapter package for Next.js applications running on a **long-lived Node.js server** (`next start` or equivalent). It instruments the Node `http` / `https` server to collect queue time, application time, and utilization for every request (including App Router, Pages Router, Route Handlers, and RSC), without adding framework middleware.
+
+## Set up your Next.js app for autoscaling
+
+1. Install packages:
+
+```sh
+npm install judoscale-nextjs --save
+```
+
+2. Enable the instrumentation hook (Next.js 14 needs this in `next.config.js`; Next.js 15+ enables it by default):
+
+```js
+// next.config.js
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}
+
+module.exports = nextConfig
+```
+
+3. Add `instrumentation.ts` (or `.js`) at the project root (or under `src/` if you use a `src/` layout):
+
+```ts
+// instrumentation.ts
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { register: registerJudoscale } = await import('judoscale-nextjs')
+    registerJudoscale({
+      // Same options as `new Judoscale({ ... })` from judoscale-node-core
+      // api_base_url: process.env.JUDOSCALE_URL,
+      // log_level: 'debug',
+    })
+  }
+}
+```
+
+**Use the Node.js runtime only.** This package patches Node's `http.Server`; it does not run in the Edge runtime. The `NEXT_RUNTIME === 'nodejs'` guard avoids loading it in Edge.
+
+### Optional: existing `Judoscale` instance (e.g. BullMQ)
+
+```ts
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('judoscale-bullmq')
+    const { Judoscale, register: registerJudoscale } = await import('judoscale-nextjs')
+    const redis = ... // ioredis instance
+
+    registerJudoscale({
+      judoscale: new Judoscale({
+        redis,
+        api_base_url: process.env.JUDOSCALE_URL,
+      }),
+    })
+  }
+}
+```
+
+### Custom server (Express + `next()`)
+
+If you use a custom Node server with Express, prefer [`judoscale-express`](https://www.npmjs.com/package/judoscale-express) and register its middleware instead of this package.
+
+## What is not supported
+
+- **Vercel / serverless / per-request isolates** — The reporter expects a long-running process. Use Judoscale worker adapters or a self-hosted web dyno where `next start` stays up.
+- **Edge Middleware / Edge runtime** — Not instrumented.
+
+## Configuration
+
+Same options as other Judoscale Node adapters (`logger`, `log_level`, etc.). See [judoscale-express README](https://github.com/judoscale/judoscale-node/tree/main/packages/express#configuration).
+
+## Troubleshooting
+
+Once installed, you should see something like this in your development log:
+
+> [Judoscale] Reporter not started: JUDOSCALE_URL is not set
+
+In production where `JUDOSCALE_URL` is set, you should see:
+
+> [Judoscale] Reporter starting, will report every 10 seconds
+
+Enable debug logs with `JUDOSCALE_LOG_LEVEL=debug`.
+
+Reach out to help@judoscale.com if you run into any other problems.

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "judoscale-nextjs",
+  "version": "2.0.0",
+  "description": "Next.js package for the Judoscale autoscaler",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "jest",
+    "lint": "npx standard"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/judoscale/judoscale-node.git"
+  },
+  "keywords": [
+    "heroku",
+    "autoscale",
+    "nextjs"
+  ],
+  "author": "Adam McCrea",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/judoscale/judoscale-node/issues"
+  },
+  "homepage": "https://github.com/judoscale/judoscale-node#readme",
+  "dependencies": {
+    "judoscale-node-core": "2.5.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "next": "^15.0.0",
+    "standard": "^17.1.0"
+  },
+  "peerDependencies": {
+    "next": "^14.0.0 || ^15.0.0"
+  },
+  "standard": {
+    "globals": [
+      "describe",
+      "test",
+      "expect",
+      "beforeEach",
+      "afterEach"
+    ]
+  }
+}

--- a/packages/nextjs/src/index.js
+++ b/packages/nextjs/src/index.js
@@ -1,0 +1,7 @@
+const { Judoscale } = require('judoscale-node-core')
+const { register } = require('./instrumentation')
+
+module.exports = {
+  Judoscale,
+  register
+}

--- a/packages/nextjs/src/instrumentation.js
+++ b/packages/nextjs/src/instrumentation.js
@@ -1,0 +1,112 @@
+const http = require('http')
+const https = require('https')
+const {
+  Judoscale,
+  MetricsStore,
+  requestMetrics,
+  UtilizationTracker,
+  WebMetricsCollector
+} = require('judoscale-node-core')
+
+const packageInfo = require('../package.json')
+
+const metricsStore = new MetricsStore()
+const utilizationTracker = new UtilizationTracker()
+
+let httpPatchApplied = false
+let adapterRegistered = false
+let registerCalled = false
+let judoscaleInstance = null
+
+function instrumentRequest (req, res) {
+  utilizationTracker.start()
+  utilizationTracker.incr()
+
+  const queueTime = requestMetrics.queueTimeFromHeaders(req.headers, new Date())
+
+  if (queueTime !== null) {
+    metricsStore.push('qt', queueTime)
+  }
+
+  const startTime = requestMetrics.monotonicTime()
+
+  res.on('finish', () => {
+    const appTime = requestMetrics.elapsedTime(startTime)
+    metricsStore.push('at', appTime)
+    utilizationTracker.decr()
+  })
+}
+
+function patchOne (mod) {
+  const Server = mod.Server
+  const originalEmit = Server.prototype.emit
+  if (originalEmit.__judoscalePatched) {
+    return
+  }
+
+  function patchedEmit (event, ...args) {
+    if (event === 'request') {
+      const req = args[0]
+      const res = args[1]
+      if (req && res) {
+        instrumentRequest(req, res)
+      }
+    }
+    return originalEmit.apply(this, [event, ...args])
+  }
+
+  patchedEmit.__judoscalePatched = true
+  patchedEmit.__judoscaleOriginalEmit = originalEmit
+  Server.prototype.emit = patchedEmit
+}
+
+function ensureHttpInstrumentation () {
+  if (httpPatchApplied) {
+    return
+  }
+  patchOne(http)
+  patchOne(https)
+  httpPatchApplied = true
+}
+
+function ensureAdapterRegistered () {
+  if (adapterRegistered) {
+    return
+  }
+
+  const nextPackageInfo = require('next/package.json')
+
+  Judoscale.registerAdapter(
+    'judoscale-nextjs',
+    new WebMetricsCollector(metricsStore, utilizationTracker),
+    {
+      adapter_version: packageInfo.version,
+      runtime_version: nextPackageInfo.version
+    }
+  )
+  adapterRegistered = true
+}
+
+function register (options = {}) {
+  if (process.env.NEXT_RUNTIME && process.env.NEXT_RUNTIME !== 'nodejs') {
+    return undefined
+  }
+
+  if (registerCalled) {
+    return judoscaleInstance
+  }
+
+  registerCalled = true
+
+  ensureHttpInstrumentation()
+  ensureAdapterRegistered()
+
+  const { judoscale, ...judoscaleOptions } = options
+  judoscaleInstance = judoscale ?? new Judoscale(judoscaleOptions)
+
+  return judoscaleInstance
+}
+
+module.exports = {
+  register
+}

--- a/packages/nextjs/test/instrumentation.edge.test.js
+++ b/packages/nextjs/test/instrumentation.edge.test.js
@@ -1,0 +1,11 @@
+/* global test, expect */
+
+// NEXT_RUNTIME must be set before loading the module under test
+process.env.NEXT_RUNTIME = 'edge'
+
+const { register } = require('../src/index')
+
+test('register skips when NEXT_RUNTIME is edge', () => {
+  expect(register()).toBeUndefined()
+  expect(register()).toBeUndefined()
+})

--- a/packages/nextjs/test/instrumentation.test.js
+++ b/packages/nextjs/test/instrumentation.test.js
@@ -1,0 +1,92 @@
+/* global test, expect, describe, beforeAll */
+
+const http = require('http')
+const { Judoscale, register } = require('../src/index')
+
+const nextAdapter = () =>
+  Judoscale.adapters.find((a) => a.identifier === 'judoscale-nextjs')
+
+beforeAll(() => {
+  register({})
+})
+
+test('adapter is registered', () => {
+  expect(nextAdapter()).toBeDefined()
+  expect(nextAdapter().identifier).toEqual('judoscale-nextjs')
+  expect(nextAdapter().meta.runtime_version).toBeDefined()
+})
+
+test('register is idempotent', () => {
+  const j = register({})
+  expect(register({})).toBe(j)
+})
+
+describe('HTTP instrumentation', () => {
+  test('captures request queue time and app time from collector', async () => {
+    const simulatedHeaderTime = Date.now() - 100
+
+    const server = http.createServer((_req, res) => {
+      res.end('ok')
+    })
+
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const { port } = server.address()
+
+    await new Promise((resolve, reject) => {
+      http.get(
+        {
+          hostname: '127.0.0.1',
+          port,
+          path: '/',
+          headers: { 'x-request-start': simulatedHeaderTime.toString() }
+        },
+        (res) => {
+          res.on('data', () => {})
+          res.on('end', resolve)
+        }
+      ).on('error', reject)
+    })
+
+    server.close()
+
+    const metrics = nextAdapter().collector.collect()
+    expect(metrics.length).toEqual(3)
+    expect(metrics[0].identifier).toEqual('qt')
+    expect(metrics[0].value).toBeGreaterThanOrEqual(100)
+    expect(metrics[0].value).toBeLessThan(200)
+    expect(metrics[1].identifier).toEqual('at')
+    expect(metrics[1].value).toBeGreaterThanOrEqual(0)
+    expect(metrics[2].identifier).toEqual('up')
+    expect(metrics[2].value).toBeGreaterThanOrEqual(0)
+  })
+
+  test('gracefully handles missing queue time', async () => {
+    const server = http.createServer((_req, res) => {
+      res.end('ok')
+    })
+
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const { port } = server.address()
+
+    await new Promise((resolve, reject) => {
+      http.get(
+        {
+          hostname: '127.0.0.1',
+          port,
+          path: '/'
+        },
+        (res) => {
+          res.on('data', () => {})
+          res.on('end', resolve)
+        }
+      ).on('error', reject)
+    })
+
+    server.close()
+
+    const metrics = nextAdapter().collector.collect()
+    expect(metrics.length).toEqual(2)
+    expect(metrics[0].identifier).toEqual('at')
+    expect(metrics[1].identifier).toEqual('up')
+  })
+})

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,9 @@
     },
     "packages/bull": {
       "release-type": "node"
+    },
+    "packages/nextjs": {
+      "release-type": "node"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/sample_apps/next_web/Procfile
+++ b/sample_apps/next_web/Procfile
@@ -1,0 +1,3 @@
+proxy: npx judoscale-adapter-proxy-server
+web: npm run start
+worker: npm run worker

--- a/sample_apps/next_web/README.md
+++ b/sample_apps/next_web/README.md
@@ -1,0 +1,26 @@
+# Judoscale Next.js sample
+
+Mirrors [express_web](../express_web): Next.js App Router with `judoscale-nextjs` (web metrics) and `judoscale-bullmq` (queues).
+
+## Run locally
+
+```sh
+npm install
+# Redis required for BullMQ
+npm run dev
+```
+
+In another terminal:
+
+```sh
+npm run worker
+```
+
+Build + production-like server:
+
+```sh
+npm run build
+npm run start
+```
+
+Reports go to Request Catcher unless `JUDOSCALE_URL` is set.

--- a/sample_apps/next_web/app/api/enqueue-jobs/route.js
+++ b/sample_apps/next_web/app/api/enqueue-jobs/route.js
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+import { Queue } from 'bullmq'
+import Redis from 'ioredis'
+
+const redis = new Redis(process.env.REDIS_URL || 'redis://127.0.0.1:6379', {
+  maxRetriesPerRequest: null,
+  enableReadyCheck: false
+})
+
+export async function POST (request) {
+  const formData = await request.formData()
+  const queueName = String(formData.get('queue') || 'default')
+  const numJobs = Number(formData.get('jobs')) || 10
+  const duration = Number(formData.get('duration')) || 10
+
+  const queue = new Queue(queueName, { connection: redis })
+  const bulkJobArgs = Array.from({ length: numJobs }, () => ({
+    name: 'testJob',
+    data: { duration }
+  }))
+
+  try {
+    await queue.addBulk(bulkJobArgs)
+    console.log(`${numJobs} jobs added to ${queueName} queue`)
+  } catch (error) {
+    console.error('Error enqueuing jobs:', error)
+    await queue.close()
+    return new NextResponse('Failed to enqueue jobs', { status: 500 })
+  }
+
+  await queue.close()
+  return NextResponse.redirect(new URL('/', request.url))
+}

--- a/sample_apps/next_web/app/layout.jsx
+++ b/sample_apps/next_web/app/layout.jsx
@@ -1,0 +1,16 @@
+export default function RootLayout ({ children }) {
+  return (
+    <html lang='en'>
+      <head>
+        <meta charSet='utf-8' />
+        <meta name='viewport' content='width=device-width, initial-scale=1' />
+        <meta name='color-scheme' content='light dark' />
+        <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.cyan.min.css' />
+        <title>Judoscale sample app</title>
+      </head>
+      <body>
+        <main className='container'>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/sample_apps/next_web/app/page.jsx
+++ b/sample_apps/next_web/app/page.jsx
@@ -1,0 +1,104 @@
+import Redis from 'ioredis'
+import { Queue } from 'bullmq'
+
+const redis = new Redis(process.env.REDIS_URL || 'redis://127.0.0.1:6379', {
+  maxRetriesPerRequest: null,
+  enableReadyCheck: false
+})
+
+const sleep = (secs) => new Promise((resolve) => setTimeout(resolve, secs * 1000))
+const randomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min
+
+export default async function Page ({ searchParams }) {
+  const sp = await searchParams
+  if (sp.sleep) {
+    const sleepFor = parseInt(String(sp.sleep), 10)
+    await sleep(Number.isNaN(sleepFor) ? randomInt(0, 2) : sleepFor)
+  }
+
+  const keys = await redis.keys('bull:*:id')
+  const queueNames = keys.map((key) => key.split(':')[1])
+
+  const queueStats = await Promise.all(
+    queueNames.map(async (name) => {
+      const queue = new Queue(name, { connection: redis })
+      const jobCounts = await queue.getJobCounts('waiting', 'active')
+      await queue.close()
+      return {
+        name,
+        enqueuedJobs: jobCounts.waiting,
+        activeJobs: jobCounts.active
+      }
+    })
+  )
+
+  return (
+    <>
+      <h1>Judoscale sample app (Next.js)</h1>
+
+      <p>
+        This app uses the App Router with <code>judoscale-nextjs</code> and <code>judoscale-bullmq</code>.
+        Visit{' '}
+        <a href='https://judoscale-node.requestcatcher.com' target='_blank' rel='noreferrer'>
+          judoscale-node.requestcatcher.com
+        </a>{' '}
+        to view outbound reports.
+      </p>
+
+      <p>
+        Reload with <code>?sleep=N</code> to slow the request, or use the form to enqueue BullMQ jobs.
+      </p>
+
+      <div className='grid'>
+        <div>
+          <h2>Job Queues</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Queue</th>
+                <th>Enqueued Jobs</th>
+                <th>Active Jobs</th>
+              </tr>
+            </thead>
+            <tbody>
+              {queueStats.map((queue) => (
+                <tr key={queue.name}>
+                  <td>{queue.name}</td>
+                  <td>{queue.enqueuedJobs}</td>
+                  <td>{queue.activeJobs}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <article>
+          <h2>Enqueue Jobs</h2>
+          <form action='/api/enqueue-jobs' method='post'>
+            <label>
+              <span>Queue</span>
+              <select name='queue' required>
+                <option value='default'>default</option>
+                <option value='urgent'>urgent</option>
+              </select>
+            </label>
+
+            <label>
+              <span>Jobs to enqueue</span>
+              <input type='number' name='jobs' min='1' max='100' defaultValue='10' required />
+            </label>
+
+            <label>
+              <span>Job duration (sec)</span>
+              <input type='number' name='duration' min='1' max='100' defaultValue='5' required />
+            </label>
+
+            <div>
+              <button type='submit'>Enqueue Jobs</button>
+            </div>
+          </form>
+        </article>
+      </div>
+    </>
+  )
+}

--- a/sample_apps/next_web/instrumentation.js
+++ b/sample_apps/next_web/instrumentation.js
@@ -1,0 +1,17 @@
+export async function register () {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('judoscale-bullmq')
+    const { register: registerJudoscale } = await import('judoscale-nextjs')
+    const { default: Redis } = await import('ioredis')
+
+    const redis = new Redis(process.env.REDIS_URL || 'redis://127.0.0.1:6379', {
+      maxRetriesPerRequest: null,
+      enableReadyCheck: false
+    })
+
+    registerJudoscale({
+      api_base_url: process.env.JUDOSCALE_URL || 'https://judoscale-node.requestcatcher.com',
+      redis
+    })
+  }
+}

--- a/sample_apps/next_web/next.config.mjs
+++ b/sample_apps/next_web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // Next.js 14 requires `experimental.instrumentationHook`. Next.js 15+ enables instrumentation by default.
+}
+
+export default nextConfig

--- a/sample_apps/next_web/package.json
+++ b/sample_apps/next_web/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "judoscale-sample-next",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "worker": "node src/worker.js"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "bullmq": "^5.7.9",
+    "ioredis": "^5.6.0",
+    "judoscale-bullmq": "*",
+    "judoscale-nextjs": "*",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/sample_apps/next_web/src/worker.js
+++ b/sample_apps/next_web/src/worker.js
@@ -1,0 +1,43 @@
+import Redis from 'ioredis'
+import { Worker } from 'bullmq'
+import { Judoscale } from 'judoscale-bullmq'
+
+const redis = new Redis(process.env.REDIS_URL || 'redis://127.0.0.1:6379', {
+  maxRetriesPerRequest: null,
+  enableReadyCheck: false
+})
+const queueNames = ['default', 'urgent']
+
+new Judoscale({
+  api_base_url: process.env.JUDOSCALE_URL || 'https://judoscale-node.requestcatcher.com',
+  redis
+})
+
+const workers = queueNames.map((queueName) => {
+  console.log(`Starting worker for ${queueName} queue`)
+  return new Worker(queueName, handlerForQueue(queueName), { connection: redis })
+})
+
+process.on('SIGINT', () => gracefulShutdown('SIGINT'))
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'))
+
+function handlerForQueue (queueName) {
+  return async (job) => {
+    console.log(`Processing job ${job.id} from ${queueName} queue for ${job.data.duration} seconds`)
+    await sleep(job.data.duration * 1000)
+    console.log(`Completed job ${job.id} from ${queueName} queue`)
+  }
+}
+
+async function sleep (ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function gracefulShutdown (signal) {
+  console.log(`Received ${signal}, shutting down workers...`)
+  for (const worker of workers) {
+    await worker.close()
+  }
+
+  process.exit(0)
+}


### PR DESCRIPTION
## Summary

- New `judoscale-nextjs` workspace package: `register()` runs from `instrumentation.ts` on the Node runtime, patches `http`/`https` `Server.prototype.emit` once, and reuses the existing `MetricsStore` / `UtilizationTracker` / `WebMetricsCollector` so queue time, app time, and utilization are recorded for every Next.js request (App Router, Pages, Route Handlers, RSC) without any user middleware.
- Skips automatically when `NEXT_RUNTIME !== 'nodejs'` (Edge runtime no-op) and is idempotent across `next dev` HMR reloads via a `__judoscalePatched` flag.
- Sample app `sample_apps/next_web` (App Router page, BullMQ enqueue route, instrumentation hook, worker, Procfile) mirroring `sample_apps/express_web`.
- CI matrix `nextjs.yml` covering Node 20/22/24/25 × Next 14.x/15.x.
- `release-please` config + manifest seeded at `2.0.0` to match the rest of the family; root README updated; `bin/publish` already iterates `packages/*`.

Refs JDO-796.

## Test plan

- [x] `npm test` (all workspaces pass, including new `judoscale-nextjs` suite)
- [x] `npm run lint` in `packages/nextjs`
- [x] `next build` succeeds in `sample_apps/next_web`
- [x] Tests pass against Next 14.x and Next 15.x
- [ ] Smoke-test in a real Next.js app: confirm reporter starts and metrics show up in the Judoscale dashboard / Request Catcher


Made with [Cursor](https://cursor.com)