### PR TITLE
fix: Read Scalingo container identity from CONTAINER env var

### DIFF
--- a/packages/node-core/src/config.js
+++ b/packages/node-core/src/config.js
@@ -28,6 +28,9 @@ function getDefaultOptions() {
     containerID = process.env.FLY_MACHINE_ID
   } else if (process.env.RAILWAY_REPLICA_ID) {
     containerID = process.env.RAILWAY_REPLICA_ID
+  } else if (process.env.CONTAINER) {
+    // Scalingo exposes the container type and index (e.g. "web-1") via CONTAINER.
+    containerID = process.env.CONTAINER
   }
 
   return {

--- a/packages/node-core/test/config.test.js
+++ b/packages/node-core/test/config.test.js
@@ -13,6 +13,7 @@ describe('Config', () => {
     delete process.env.ECS_CONTAINER_METADATA_URI
     delete process.env.FLY_MACHINE_ID
     delete process.env.RAILWAY_REPLICA_ID
+    delete process.env.CONTAINER
   })
 
   test('has logger property', () => {
@@ -66,6 +67,11 @@ describe('Config', () => {
   test('has container property for Railway', () => {
     process.env.RAILWAY_REPLICA_ID = 'random-replica-uuid'
     expect(new Config()).toHaveProperty('container', 'random-replica-uuid')
+  })
+
+  test('has container property for Scalingo', () => {
+    process.env.CONTAINER = 'web-1'
+    expect(new Config()).toHaveProperty('container', 'web-1')
   })
 
   test('has container property via JUDOSCALE_CONTAINER', () => {


### PR DESCRIPTION
## Summary

- Detect Scalingo's runtime `CONTAINER` env var (e.g. `web-1`) in `judoscale-node-core`'s config so adapter reports include real container metadata instead of the dashboard showing `[missing]`.
- Placed last in the platform-detection chain (lowest priority), matching the ordering in [judoscale-ruby#271](https://github.com/judoscale/judoscale-ruby/pull/271); `JUDOSCALE_CONTAINER` still overrides everything.

### Not ported

The Ruby PR's second commit (skip redundant Scalingo job-metrics collection via `RuntimeContainer#redundant_instance?`) has no equivalent here — this lib has no `RuntimeContainer` class and never skips job-metrics collection on redundant instances (Bull/BullMQ collectors run unconditionally). Porting it would be a new feature rather than applying this fix.

## Test plan

- [x] `npm test` in `packages/node-core` passes (57 tests), including the new `has container property for Scalingo` case

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive env detection and unit tests; no auth, data, or reporting protocol changes beyond filling container when CONTAINER is set.
> 
> **Overview**
> **Scalingo** deployments on `judoscale-node-core` now populate adapter **`container`** metadata from the platform’s **`CONTAINER`** env var (e.g. `web-1`), so reports no longer show missing container identity in the dashboard.
> 
> Detection is added at the **end** of the existing platform chain (after Fly/Railway, etc.); **`JUDOSCALE_CONTAINER`** still wins when set. Tests cover the new branch and reset **`CONTAINER`** in **`beforeEach`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e398defc3888354681d5ee369adc15cf20bce4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->