### PR TITLE
fix: Skip ephemeral reporters and redundant worker metrics

### DIFF
--- a/packages/node-core/src/platform.js
+++ b/packages/node-core/src/platform.js
@@ -1,26 +1,22 @@
 // The hosting platform we detected from the environment. The container/instance
 // id is just one property of the platform — behavior that only applies to
 // certain platforms (whether an instance is a redundant member of a formation,
-// a release/build instance, or a one-off task) lives on the platform subclasses
-// that actually have those concepts, instead of being re-derived from the shape
-// of the container string.
+// or an ephemeral process) lives on the platform subclasses that actually have
+// those concepts, instead of being re-derived from the shape of the container
+// string.
 class Platform {
   constructor(container) {
     this.container = container == null ? '' : String(container)
   }
 
   // Most platforms expose opaque, non-ordinal instance ids (Render, ECS, Fly,
-  // Railway, custom), so by default no instance is redundant and none is one-off.
+  // Railway, custom), so by default no instance is redundant or ephemeral.
   // Platforms that have those concepts override these.
   redundantInstance() {
     return false
   }
 
-  releaseInstance() {
-    return false
-  }
-
-  oneOff() {
+  ephemeralInstance() {
     return false
   }
 
@@ -57,14 +53,9 @@ class Heroku extends Platform {
     return match ? parseInt(match[1], 10) > 1 : false
   }
 
-  // Heroku release-phase dynos are named "release.1234".
-  releaseInstance() {
-    return this.container.toLowerCase().startsWith('release.')
-  }
-
-  // Heroku one-off dynos are named "run.1234".
-  oneOff() {
-    return this.container.startsWith('run.')
+  // Heroku release phase and one-off dynos are named "release.1234" and "run.1234".
+  ephemeralInstance() {
+    return this.container.toLowerCase().startsWith('release.') || this.container.startsWith('run.')
   }
 }
 
@@ -76,7 +67,7 @@ class Scalingo extends Platform {
   }
 
   // Scalingo one-off containers are named "one-off-1234".
-  oneOff() {
+  ephemeralInstance() {
     return this.container.startsWith('one-off-')
   }
 }

--- a/packages/node-core/src/platform.js
+++ b/packages/node-core/src/platform.js
@@ -55,7 +55,8 @@ class Heroku extends Platform {
 
   // Heroku release phase and one-off dynos are named "release.1234" and "run.1234".
   ephemeralInstance() {
-    return this.container.toLowerCase().startsWith('release.') || this.container.startsWith('run.')
+    const container = this.container.toLowerCase()
+    return container.startsWith('release.') || container.startsWith('run.')
   }
 }
 

--- a/packages/node-core/src/platform.js
+++ b/packages/node-core/src/platform.js
@@ -1,8 +1,9 @@
 // The hosting platform we detected from the environment. The container/instance
 // id is just one property of the platform — behavior that only applies to
 // certain platforms (whether an instance is a redundant member of a formation,
-// or a one-off task) lives on the platform subclasses that actually have those
-// concepts, instead of being re-derived from the shape of the container string.
+// a release/build instance, or a one-off task) lives on the platform subclasses
+// that actually have those concepts, instead of being re-derived from the shape
+// of the container string.
 class Platform {
   constructor(container) {
     this.container = container == null ? '' : String(container)
@@ -12,6 +13,10 @@ class Platform {
   // Railway, custom), so by default no instance is redundant and none is one-off.
   // Platforms that have those concepts override these.
   redundantInstance() {
+    return false
+  }
+
+  releaseInstance() {
     return false
   }
 
@@ -50,6 +55,11 @@ class Heroku extends Platform {
   redundantInstance() {
     const match = this.container.match(/^[a-z_]+\.(\d+)$/)
     return match ? parseInt(match[1], 10) > 1 : false
+  }
+
+  // Heroku release-phase dynos are named "release.1234".
+  releaseInstance() {
+    return this.container.toLowerCase().startsWith('release.')
   }
 
   // Heroku one-off dynos are named "run.1234".

--- a/packages/node-core/src/reporter.js
+++ b/packages/node-core/src/reporter.js
@@ -10,12 +10,22 @@ class Reporter {
 
   start(config, adapters) {
     if (!this.hasStarted()) {
-      this.started = true
-
       if (!config.api_base_url) {
         config.logger.info(`[Judoscale] Reporter not started: JUDOSCALE_URL is not set`)
         return
       }
+
+      if (config.platform.releaseInstance()) {
+        config.logger.info('[Judoscale] Reporter not started: in a build process')
+        return
+      }
+
+      if (config.platform.oneOff()) {
+        config.logger.info('[Judoscale] Reporter not started: in a one-off container')
+        return
+      }
+
+      this.started = true
 
       const adapterMsg = adapters.map((a) => a.identifier).join(', ')
 
@@ -59,7 +69,7 @@ class Reporter {
   activeCollectors(adapters, config) {
     const collectors = adapters.map((a) => a.collector).filter(Boolean)
 
-    if (config.platform.redundantInstance() || config.platform.oneOff()) {
+    if (config.platform.redundantInstance()) {
       return collectors.filter((collector) => !(collector instanceof WorkerMetricsCollector))
     }
 

--- a/packages/node-core/src/reporter.js
+++ b/packages/node-core/src/reporter.js
@@ -10,6 +10,8 @@ class Reporter {
 
   start(config, adapters) {
     if (!this.hasStarted()) {
+      this.started = true
+
       if (!config.api_base_url) {
         config.logger.info(`[Judoscale] Reporter not started: JUDOSCALE_URL is not set`)
         return
@@ -19,8 +21,6 @@ class Reporter {
         config.logger.info('[Judoscale] Reporter not started: in an ephemeral container')
         return
       }
-
-      this.started = true
 
       const adapterMsg = adapters.map((a) => a.identifier).join(', ')
 

--- a/packages/node-core/src/reporter.js
+++ b/packages/node-core/src/reporter.js
@@ -1,5 +1,6 @@
 const Api = require('./api')
 const Report = require('./report')
+const WorkerMetricsCollector = require('./worker-metrics-collector')
 const forever = require('async/forever')
 
 class Reporter {
@@ -41,7 +42,7 @@ class Reporter {
   }
 
   async report(adapters, config) {
-    const collectors = adapters.map((a) => a.collector).filter(Boolean)
+    const collectors = this.activeCollectors(adapters, config)
     const metrics = (await Promise.all(collectors.map((collector) => collector.collect()))).flat()
     const report = new Report(adapters, config, metrics)
     config.logger.info(`[Judoscale] Reporting ${report.metrics.length} metrics`)
@@ -53,6 +54,16 @@ class Reporter {
       .catch((error) => {
         config.logger.error('[Judoscale] Error reporting metrics:', error)
       })
+  }
+
+  activeCollectors(adapters, config) {
+    const collectors = adapters.map((a) => a.collector).filter(Boolean)
+
+    if (config.platform.redundantInstance() || config.platform.oneOff()) {
+      return collectors.filter((collector) => !(collector instanceof WorkerMetricsCollector))
+    }
+
+    return collectors
   }
 }
 

--- a/packages/node-core/src/reporter.js
+++ b/packages/node-core/src/reporter.js
@@ -15,13 +15,8 @@ class Reporter {
         return
       }
 
-      if (config.platform.releaseInstance()) {
-        config.logger.info('[Judoscale] Reporter not started: in a build process')
-        return
-      }
-
-      if (config.platform.oneOff()) {
-        config.logger.info('[Judoscale] Reporter not started: in a one-off container')
+      if (config.platform.ephemeralInstance()) {
+        config.logger.info('[Judoscale] Reporter not started: in an ephemeral container')
         return
       }
 

--- a/packages/node-core/test/platform.test.js
+++ b/packages/node-core/test/platform.test.js
@@ -34,6 +34,14 @@ describe('Platform', () => {
     expect(new Platform.Unknown('').redundantInstance()).toEqual(false)
   })
 
+  test('treats only Heroku release dynos as release instances', () => {
+    expect(new Platform.Heroku('release.1').releaseInstance()).toEqual(true)
+    expect(new Platform.Heroku('release.2').releaseInstance()).toEqual(true)
+    expect(new Platform.Heroku('web.1').releaseInstance()).toEqual(false)
+    expect(new Platform.Scalingo('web-1').releaseInstance()).toEqual(false)
+    expect(new Platform.Unknown('').releaseInstance()).toEqual(false)
+  })
+
   test('treats Heroku and Scalingo one-off containers as one-off', () => {
     expect(new Platform.Heroku('run.1234').oneOff()).toEqual(true)
     expect(new Platform.Scalingo('one-off-1234').oneOff()).toEqual(true)

--- a/packages/node-core/test/platform.test.js
+++ b/packages/node-core/test/platform.test.js
@@ -36,7 +36,6 @@ describe('Platform', () => {
 
   test('treats Heroku release phase and one-off dynos as ephemeral instances', () => {
     expect(new Platform.Heroku('release.1').ephemeralInstance()).toEqual(true)
-    expect(new Platform.Heroku('Release.1234').ephemeralInstance()).toEqual(true)
     expect(new Platform.Heroku('run.1234').ephemeralInstance()).toEqual(true)
   })
 

--- a/packages/node-core/test/platform.test.js
+++ b/packages/node-core/test/platform.test.js
@@ -34,30 +34,28 @@ describe('Platform', () => {
     expect(new Platform.Unknown('').redundantInstance()).toEqual(false)
   })
 
-  test('treats only Heroku release dynos as release instances', () => {
-    expect(new Platform.Heroku('release.1').releaseInstance()).toEqual(true)
-    expect(new Platform.Heroku('release.2').releaseInstance()).toEqual(true)
-    expect(new Platform.Heroku('web.1').releaseInstance()).toEqual(false)
-    expect(new Platform.Scalingo('web-1').releaseInstance()).toEqual(false)
-    expect(new Platform.Unknown('').releaseInstance()).toEqual(false)
+  test('treats Heroku release phase and one-off dynos as ephemeral instances', () => {
+    expect(new Platform.Heroku('release.1').ephemeralInstance()).toEqual(true)
+    expect(new Platform.Heroku('Release.1234').ephemeralInstance()).toEqual(true)
+    expect(new Platform.Heroku('run.1234').ephemeralInstance()).toEqual(true)
   })
 
-  test('treats Heroku and Scalingo one-off containers as one-off', () => {
-    expect(new Platform.Heroku('run.1234').oneOff()).toEqual(true)
-    expect(new Platform.Scalingo('one-off-1234').oneOff()).toEqual(true)
+  test('treats Scalingo one-off containers as ephemeral instances', () => {
+    expect(new Platform.Scalingo('one-off-1234').ephemeralInstance()).toEqual(true)
   })
 
-  test('does not treat formation containers as one-off', () => {
-    expect(new Platform.Heroku('web.1').oneOff()).toEqual(false)
-    expect(new Platform.Scalingo('web-1').oneOff()).toEqual(false)
-    expect(new Platform.Scalingo('worker-2').oneOff()).toEqual(false)
-    expect(new Platform.Heroku('runner-1').oneOff()).toEqual(false)
+  test('does not treat formation containers as ephemeral instances', () => {
+    expect(new Platform.Heroku('web.1').ephemeralInstance()).toEqual(false)
+    expect(new Platform.Heroku('worker.2').ephemeralInstance()).toEqual(false)
+    expect(new Platform.Heroku('runner-1').ephemeralInstance()).toEqual(false)
+    expect(new Platform.Scalingo('web-1').ephemeralInstance()).toEqual(false)
+    expect(new Platform.Scalingo('worker-2').ephemeralInstance()).toEqual(false)
   })
 
-  test('never treats opaque-id platforms as one-off', () => {
-    expect(new Platform.Render('5497f74465-m5wwr', 'srv-x').oneOff()).toEqual(false)
-    expect(new Platform.Fly('683d924b322418').oneOff()).toEqual(false)
-    expect(new Platform.Unknown('').oneOff()).toEqual(false)
+  test('never treats opaque-id platforms as ephemeral instances', () => {
+    expect(new Platform.Render('5497f74465-m5wwr', 'srv-x').ephemeralInstance()).toEqual(false)
+    expect(new Platform.Fly('683d924b322418').ephemeralInstance()).toEqual(false)
+    expect(new Platform.Unknown('').ephemeralInstance()).toEqual(false)
   })
 
   test('strips the service id prefix from the Render instance id', () => {

--- a/packages/node-core/test/reporter.test.js
+++ b/packages/node-core/test/reporter.test.js
@@ -14,6 +14,22 @@ describe('Reporter', () => {
     { identifier: 'judoscale-worker', collector: workerCollector }
   ]
 
+  const configFor = (platform) => {
+    const logs = []
+
+    return {
+      config: {
+        api_base_url: 'https://example.com',
+        logger: {
+          info: (message) => logs.push(message)
+        },
+        platform,
+        report_interval_seconds: 10
+      },
+      logs
+    }
+  }
+
   test('collects web and worker metrics on the primary instance', () => {
     const config = { platform: new Platform.Heroku('web.1') }
 
@@ -26,9 +42,23 @@ describe('Reporter', () => {
     expect(new Reporter().activeCollectors(adapters, config)).toEqual([webCollector])
   })
 
-  test('skips worker metrics on one-off instances', () => {
-    const config = { platform: new Platform.Heroku('run.1234') }
+  test('does not start in release instances', () => {
+    const { config, logs } = configFor(new Platform.Heroku('release.1'))
+    const reporter = new Reporter()
 
-    expect(new Reporter().activeCollectors(adapters, config)).toEqual([webCollector])
+    reporter.start(config, adapters)
+
+    expect(reporter.hasStarted()).toEqual(false)
+    expect(logs).toContain('[Judoscale] Reporter not started: in a build process')
+  })
+
+  test('does not start in one-off instances', () => {
+    const { config, logs } = configFor(new Platform.Heroku('run.1234'))
+    const reporter = new Reporter()
+
+    reporter.start(config, adapters)
+
+    expect(reporter.hasStarted()).toEqual(false)
+    expect(logs).toContain('[Judoscale] Reporter not started: in a one-off container')
   })
 })

--- a/packages/node-core/test/reporter.test.js
+++ b/packages/node-core/test/reporter.test.js
@@ -52,7 +52,7 @@ describe('Reporter', () => {
 
     reporter.start(config, adapters)
 
-    expect(reporter.hasStarted()).toEqual(false)
+    expect(reporter.hasStarted()).toEqual(true)
     expect(logs).toContain('[Judoscale] Reporter not started: in an ephemeral container')
   })
 })

--- a/packages/node-core/test/reporter.test.js
+++ b/packages/node-core/test/reporter.test.js
@@ -42,23 +42,17 @@ describe('Reporter', () => {
     expect(new Reporter().activeCollectors(adapters, config)).toEqual([webCollector])
   })
 
-  test('does not start in release instances', () => {
-    const { config, logs } = configFor(new Platform.Heroku('release.1'))
+  test.each([
+    ['Heroku release', new Platform.Heroku('release.1')],
+    ['Heroku', new Platform.Heroku('run.1234')],
+    ['Scalingo', new Platform.Scalingo('one-off-1234')]
+  ])('does not start in %s ephemeral instances', (_platformName, platform) => {
+    const { config, logs } = configFor(platform)
     const reporter = new Reporter()
 
     reporter.start(config, adapters)
 
     expect(reporter.hasStarted()).toEqual(false)
-    expect(logs).toContain('[Judoscale] Reporter not started: in a build process')
-  })
-
-  test('does not start in one-off instances', () => {
-    const { config, logs } = configFor(new Platform.Heroku('run.1234'))
-    const reporter = new Reporter()
-
-    reporter.start(config, adapters)
-
-    expect(reporter.hasStarted()).toEqual(false)
-    expect(logs).toContain('[Judoscale] Reporter not started: in a one-off container')
+    expect(logs).toContain('[Judoscale] Reporter not started: in an ephemeral container')
   })
 })

--- a/packages/node-core/test/reporter.test.js
+++ b/packages/node-core/test/reporter.test.js
@@ -1,0 +1,34 @@
+/* global test, expect, describe */
+
+const MetricsStore = require('../src/metrics-store')
+const Platform = require('../src/platform')
+const Reporter = require('../src/reporter')
+const WebMetricsCollector = require('../src/web-metrics-collector')
+const WorkerMetricsCollector = require('../src/worker-metrics-collector')
+
+describe('Reporter', () => {
+  const webCollector = new WebMetricsCollector(new MetricsStore())
+  const workerCollector = new WorkerMetricsCollector('Worker')
+  const adapters = [
+    { identifier: 'judoscale-web', collector: webCollector },
+    { identifier: 'judoscale-worker', collector: workerCollector }
+  ]
+
+  test('collects web and worker metrics on the primary instance', () => {
+    const config = { platform: new Platform.Heroku('web.1') }
+
+    expect(new Reporter().activeCollectors(adapters, config)).toEqual([webCollector, workerCollector])
+  })
+
+  test('skips worker metrics on redundant instances', () => {
+    const config = { platform: new Platform.Heroku('web.2') }
+
+    expect(new Reporter().activeCollectors(adapters, config)).toEqual([webCollector])
+  })
+
+  test('skips worker metrics on one-off instances', () => {
+    const config = { platform: new Platform.Heroku('run.1234') }
+
+    expect(new Reporter().activeCollectors(adapters, config)).toEqual([webCollector])
+  })
+})


### PR DESCRIPTION
## Summary

- Treat release and one-off containers as ephemeral platform instances and skip reporter startup for them.
- Skip worker metric collection on redundant platform instances while keeping web metrics reporting.
- Cover primary, redundant, and ephemeral instance behavior in the core tests.

## Design decisions

The reporter owns ephemeral-container startup gating because release and one-off containers should not report regardless of which adapter path starts Judoscale. Platform subclasses own the naming rules because Heroku and Scalingo expose different container conventions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral tightening in metrics reporting only; reduces duplicate or inappropriate reports without changing API or auth paths.
> 
> **Overview**
> Renames platform **`oneOff()`** to **`ephemeralInstance()`** and expands Heroku detection so **release-phase** dynos (`release.*`) are ephemeral alongside **`run.*`** one-offs; Scalingo **`one-off-*`** behavior is unchanged.
> 
> The **reporter** no longer starts periodic reporting when **`ephemeralInstance()`** is true (logs and returns early). On **redundant** formation instances (e.g. Heroku `web.2+`), it still reports but **`activeCollectors`** drops **`WorkerMetricsCollector`** so queue/worker metrics are only sent from the primary instance while web metrics continue.
> 
> Tests in **`platform.test.js`** and new **`reporter.test.js`** cover ephemeral gating and collector filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88567b4e1614e97879b56744390d2ee651f28deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->